### PR TITLE
🚮 mediba の suffix を削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.0.0
+
+- Changed: rename @mediba/stylelint-config-mediba to @mediba/stylelint-config
+- Added: Travis CI
+- Changed: CircleCI to v2.0
+- Added: use Prettier
+
 # 0.5.1
 
 - Changed: follow change stylelint to v7.10.1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ npm: [![npm version](https://badge.fury.io/js/%40mediba%2Fstylelint-config-medib
 ## Installation:
 
 ```bash
-$ yarn add @mediba/stylelint-config-mediba --dev
+$ yarn add @mediba/stylelint-config --dev
 ```
 
 ## Usage:
@@ -17,7 +17,7 @@ Set your `stylelint` config.
 
 ```js
 {
-  "extends": "@mediba/stylelint-config-mediba",
+  "extends": "@mediba/stylelint-config",
   "rules": {
     // If you customize rules, override here.
   }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# .style-config-mediba {
+# .style-config {
 
 **/\* stylelint config at [mediba](http://www.mediba.jp/) \*/**  
-circle-ci: [![CircleCI](https://circleci.com/gh/mediba-system/stylelint-config-mediba.svg?style=svg)](https://circleci.com/gh/mediba-system/stylelint-config-mediba);  
-travis-ci: [![Build Status](https://travis-ci.org/mediba-system/stylelint-config-mediba.svg?branch=master)](https://travis-ci.org/mediba-system/stylelint-config-mediba);  
-npm: [![npm version](https://badge.fury.io/js/%40mediba%2Fstylelint-config-mediba.svg)](https://badge.fury.io/js/%40mediba%2Fstylelint-config-mediba);
+circle-ci: [![CircleCI](https://circleci.com/gh/mediba-system/stylelint-config.svg?style=svg)](https://circleci.com/gh/mediba-system/stylelint-config);  
+travis-ci: [![Build Status](https://travis-ci.org/mediba-system/stylelint-config.svg?branch=master)](https://travis-ci.org/mediba-system/stylelint-config);  
+npm: [![npm version](https://badge.fury.io/js/%40mediba%2Fstylelint-config.svg)](https://badge.fury.io/js/%40mediba%2Fstylelint-config);
 
 ## Installation:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# .style-config {
+# .stylelint-config {
 
 **/\* stylelint config at [mediba](http://www.mediba.jp/) \*/**  
 circle-ci: [![CircleCI](https://circleci.com/gh/mediba-system/stylelint-config.svg?style=svg)](https://circleci.com/gh/mediba-system/stylelint-config);  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mediba/stylelint-config",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "description": "A stylelint config at mediba",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mediba-system/stylelint-config-mediba.git"
+    "url": "git+https://github.com/mediba-system/stylelint-config.git"
   },
   "keywords": [
     "stylelint",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A stylelint config at mediba",
   "main": "index.js",
   "scripts": {
-    "release": "npmpub",
     "test": "jest",
     "watch": "jest --watch",
     "prettier": "prettier --write --single-quote --trailing-comma all --semi false '__test__/**/*.js' '*.js'",
@@ -28,11 +27,9 @@
     "stylelint-order": "^0.4.3"
   },
   "devDependencies": {
-    "github-release-from-changelog": "^1.2.1",
     "husky": "^0.13.3",
     "jest": "^19.0.2",
     "lint-staged": "^3.4.0",
-    "npmpub": "^3.1.0",
     "prettier": "^1.1.0",
     "stylelint": "^7.10.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mediba/stylelint-config-mediba",
+  "name": "@mediba/stylelint-config",
   "version": "0.5.1",
   "description": "A stylelint config at mediba",
   "main": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@sindresorhus/df@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/df/-/df-1.0.1.tgz#c69b66f52f6fcdd287c807df210305dbaf78500d"
-
 JSONStream@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.4.tgz#91657dfe6ff857483066132b4618b62e8f4887bd"
@@ -26,13 +22,6 @@ acorn-globals@^3.1.0:
 acorn@^4.0.4:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
-
-agent-base@2:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.0.1.tgz#bd8f9e86a8eb221fffa07bd14befd55df142815e"
-  dependencies:
-    extend "~3.0.0"
-    semver "~5.0.1"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -439,10 +428,6 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-checkup@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/checkup/-/checkup-1.3.0.tgz#d3800276fea5d0f247ffc951be78c8b02f8e0d76"
-
 ci-info@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
@@ -644,7 +629,7 @@ date-fns@^1.27.2:
   version "1.28.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.3.tgz#145d87adc3f5a82c6bda668de97eee1132c97ea1"
 
-debug@2, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0:
+debug@^2.1.1, debug@^2.2.0, debug@^2.6.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
@@ -743,10 +728,6 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-escape-string-applescript@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-applescript/-/escape-string-applescript-1.0.0.tgz#6f1c2294245d82c63bc03338dc19a94aa8428892"
-
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -802,10 +783,6 @@ execall@^1.0.0:
   dependencies:
     clone-regexp "^1.0.0"
 
-execon@^1.2.0:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/execon/-/execon-1.2.9.tgz#6db11333dcc824f1f13e7317fed0d94a2f26491f"
-
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -822,7 +799,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-extend@3, extend@~3.0.0:
+extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
@@ -921,13 +898,6 @@ flow-parser@0.43.0:
   version "0.43.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.43.0.tgz#e2b8eb1ac83dd53f7b6b04a7c35b6a52c33479b7"
 
-follow-redirects@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-0.0.7.tgz#34b90bab2a911aa347571da90f22bd36ecd8a919"
-  dependencies:
-    debug "^2.2.0"
-    stream-consume "^0.1.0"
-
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -949,16 +919,6 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-fs-extra@^0.26.2:
-  version "0.26.7"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    klaw "^1.0.0"
-    path-is-absolute "^1.0.0"
-    rimraf "^2.2.8"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -990,22 +950,6 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-github-release-from-changelog@^1.1.1, github-release-from-changelog@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/github-release-from-changelog/-/github-release-from-changelog-1.2.1.tgz#0221a309d14514294ffbc4c53d9f260c0c9a313e"
-  dependencies:
-    grizzly "^2.0.0"
-    minimist "^1.2.0"
-
-github@^9.0.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/github/-/github-9.2.0.tgz#8a886dc40dd63636707dcaf99df3df26c59f16fc"
-  dependencies:
-    follow-redirects "0.0.7"
-    https-proxy-agent "^1.0.0"
-    mime "^1.2.11"
-    netrc "^0.1.4"
-
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -1030,30 +974,9 @@ glob@7.1.1, glob@^7.0.3, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^6.0.1:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 globals@^9.0.0:
   version "9.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
-
-globby@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-4.1.0.tgz#080f54549ec1b82a6c60e631fc82e1211dbe95f8"
-  dependencies:
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    glob "^6.0.1"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -1080,25 +1003,13 @@ globjoin@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-
-grizzly@^2.0.0:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/grizzly/-/grizzly-2.1.3.tgz#8ead92804b1ede275d56e0a34148bcea3dedd8a3"
-  dependencies:
-    checkup "^1.3.0"
-    debug "^2.2.0"
-    execon "^1.2.0"
-    github "^9.0.0"
-    minimist "^1.2.0"
-    os-homedir "^1.0.0"
-    readjson "^1.1.0"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -1176,14 +1087,6 @@ http-signature@~1.1.0:
     assert-plus "^0.2.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
-
-https-proxy-agent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz#35f7da6c48ce4ddbfa264891ac593ee5ff8671e6"
-  dependencies:
-    agent-base "2"
-    debug "2"
-    extend "3"
 
 husky@^0.13.3:
   version "0.13.3"
@@ -1725,12 +1628,6 @@ json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonfilter@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/jsonfilter/-/jsonfilter-1.1.2.tgz#21ef7cedc75193813c75932e96a98be205ba5a11"
@@ -1762,12 +1659,6 @@ kind-of@^3.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
   dependencies:
     is-buffer "^1.0.2"
-
-klaw@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
-  optionalDependencies:
-    graceful-fs "^4.1.9"
 
 known-css-properties@^0.0.7:
   version "0.0.7"
@@ -1974,11 +1865,7 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.27.0"
 
-mime@^1.2.11:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
-
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -1998,12 +1885,6 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mount-point@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mount-point/-/mount-point-1.2.0.tgz#f7712295e1ecd8df2e42ecbe23e07a3660807851"
-  dependencies:
-    "@sindresorhus/df" "^1.0.1"
-
 ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
@@ -2020,10 +1901,6 @@ multimatch@^2.0.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-
-netrc@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -2084,16 +1961,6 @@ npm-which@^3.0.1:
     commander "^2.9.0"
     npm-path "^2.0.2"
     which "^1.2.10"
-
-npmpub@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/npmpub/-/npmpub-3.1.0.tgz#7343a801ffb18bfd2cec233584b91459ae4ee149"
-  dependencies:
-    chalk "^1.1.1"
-    github-release-from-changelog "^1.1.1"
-    minimist "^1.2.0"
-    shelljs "^0.5.3"
-    trash "^3.4.1"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -2248,25 +2115,15 @@ performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
-pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
+pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
-
-pinkie-promise@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-1.0.0.tgz#d1da67f5482563bb7cf57f286ae2822ecfbf3670"
-  dependencies:
-    pinkie "^1.0.0"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
   dependencies:
     pinkie "^2.0.0"
-
-pinkie@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-1.0.0.tgz#5a47f28ba1015d0201bda7bf0f358e47bec8c7e4"
 
 pinkie@^2.0.0:
   version "2.0.4"
@@ -2439,12 +2296,6 @@ readable-stream@^1.0.33, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readjson@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/readjson/-/readjson-1.1.3.tgz#cb4c691551c6e4fee667f51c29cce2f5cea4593c"
-  dependencies:
-    try-catch "~1.0.0"
-
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -2553,13 +2404,6 @@ rimraf@^2.2.8, rimraf@^2.4.4:
   dependencies:
     glob "^7.0.5"
 
-run-applescript@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-2.1.0.tgz#3bff2ccf95b6ceacb49723e550f00371d618510d"
-  dependencies:
-    pify "^2.2.0"
-    pinkie-promise "^2.0.0"
-
 rxjs@^5.0.0-beta.11:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.3.0.tgz#d88ccbdd46af290cbdb97d5d8055e52453fabe2d"
@@ -2590,10 +2434,6 @@ sax@^1.2.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-semver@~5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
-
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -2607,10 +2447,6 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-
-shelljs@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.5.3.tgz#c54982b996c76ef0c1e6b59fbdc5825f5b713113"
 
 shellwords@^0.1.0:
   version "0.1.0"
@@ -2709,10 +2545,6 @@ stream-combiner@^0.2.1:
   dependencies:
     duplexer "~0.1.1"
     through "~2.3.4"
-
-stream-consume@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.0.tgz#a41ead1a6d6081ceb79f65b061901b6d8f3d1d0f"
 
 stream-to-observable@^0.1.0:
   version "0.1.0"
@@ -2935,20 +2767,6 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
-trash@^3.4.1:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/trash/-/trash-3.4.2.tgz#fb042252fc26a022276950a2bb0ece9b9405eb19"
-  dependencies:
-    escape-string-applescript "^1.0.0"
-    fs-extra "^0.26.2"
-    globby "^4.0.0"
-    path-exists "^2.0.0"
-    pify "^2.3.0"
-    pinkie-promise "^2.0.0"
-    run-applescript "^2.0.0"
-    uuid "^2.0.1"
-    xdg-trashdir "^2.0.0"
-
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -2956,10 +2774,6 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-
-try-catch@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/try-catch/-/try-catch-1.0.0.tgz#3797dab39a266775f4d0da5cbf42aca3f03608e6"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -2993,14 +2807,6 @@ uglify-to-browserify@~1.0.0:
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
-
-user-home@^1.0.0, user-home@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
-
-uuid@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.0:
   version "3.0.1"
@@ -3107,23 +2913,6 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
-
-xdg-basedir@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-1.0.1.tgz#14ff8f63a4fdbcb05d5b6eea22b36f3033b9f04e"
-  dependencies:
-    user-home "^1.0.0"
-
-xdg-trashdir@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/xdg-trashdir/-/xdg-trashdir-2.1.0.tgz#57e33efed7e68d68fd46b5d7344abab37107030c"
-  dependencies:
-    "@sindresorhus/df" "^1.0.1"
-    mount-point "^1.0.0"
-    pify "^2.2.0"
-    pinkie-promise "^1.0.0"
-    user-home "^1.1.0"
-    xdg-basedir "^1.0.0"
 
 xml-name-validator@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
npm modules を [@mediba](https://www.npmjs.com/org/mediba) に移したことにより、`-mediba` が冗長になった。

- 不要な `-mediba` をすべて削除
- リポジトリ名を `stylelint-config` に変更
- [x] stylelint-config-mediba を [deprecate](https://docs.npmjs.com/cli/deprecate) する

[@mediba/stylelint-config-mediba](https://www.npmjs.com/package/@mediba/stylelint-config-mediba) を捨てて、
[@mediba/stylelint-config](https://www.npmjs.com/package/@mediba/stylelint-config) にします。

## 関連
Fixed #7 